### PR TITLE
Improve help text, add version/date, add --git_remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+DEFAULT_GOAL := help
+PROJECT=paul_mclendahand
+
+.PHONY: help
+help:
+	@echo "Available rules:"
+	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:  /'
+
+.PHONY: test
+test:  ## Run tests
+	tox
+
+.PHONY: clean
+clean:  ## Clean build artifacts
+	rm -rf build dist ${PROJECT}.egg-info .tox
+	rm -rf docs/_build/*
+	find ${PROJECT}/ -name __pycache__ | xargs rm -rf
+	find ${PROJECT}/ -name '*.pyc' | xargs rm -rf
+
+.PHONY: lint
+lint:  ## Lint and black reformat files
+	black --target-version=py36 ${PROJECT}
+	flake8 ${PROJECT}

--- a/README.rst
+++ b/README.rst
@@ -57,16 +57,24 @@ Configure pmac
 
 pmac needs to know the GitHub user and GitHub project.
 
-You can do that using environment variables::
-
-   PMAC_GITHUB_USER=user
-   PMAC_GITHUB_PROJECT=project
-
-or by adding a section to the ``setup.cfg`` file::
+You can set configuration in the ``setup.cfg`` file::
 
    [tool:paul-mclendahand]
    github_user=user
    github_project=project
+   git_remote=git-remote-name
+
+You can override the ``setup.cfg`` variables with environment variables::
+
+   PMAC_GITHUB_USER=user
+   PMAC_GITHUB_PROJECT=project
+   PMAC_GIT_REMOTE=git-remote-name
+
+You can also pass the git remote on the command line using the ``--git_remote``
+argument.
+
+If you don't specify a remote, then pmac will guess it using a highly
+sophisticated deterministic stochastic rainbow chairs algorithm.
 
 
 Using pmac


### PR DESCRIPTION
* improve help text a bit by adding link to github issues, version, and release date
* add `--git_remote`, `PMAC_GIT_REMOTE`, and `git_remote` variables which will cause pmac to use one of those rather than guess at the remote name

Fixes #10 