### PR TITLE
Use rich for improved output. (#30)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ build==0.9.0
 check-manifest==0.49
 flake8==5.0.4
 pytest==7.2.0
+rich==12.6.0
 tox==3.27.1
 tox-gh-actions==2.11.0
 twine==4.0.2


### PR DESCRIPTION
Rich makes it easier to distinguish between pmac output and output it's printing from other things like "git am".

This also fixes a handful of bugs with "pmac add" and "pmac listprs".

Fixes #30.