### PR TITLE
Remove check-manifest from build task

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,4 +33,3 @@ build: devenv
     rm -rf build/ dist/
     uv run python -m build
     uv run twine check dist/*
-    uv run check-manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ pmac = "paul_mclendahand.cmd_pmac:pmac_cli"
 [project.optional-dependencies]
 dev = [
     "build",
-    "check-manifest",
     "cogapp",
     "pytest",
     "ruff",
@@ -48,7 +47,7 @@ dev = [
 
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
paul-mclendahand doesn't have a MANIFEST.in file, so it doesn't need to check it.